### PR TITLE
Update mathjax.html

### DIFF
--- a/_includes/mathjax.html
+++ b/_includes/mathjax.html
@@ -1,6 +1,6 @@
 <!-- Automatically display code inside script tags with type=math/tex using MathJax -->
 <script type="text/javascript" defer
-  src="/just-the-docs-tests/assets/js/mathjax-script-type.js">
+  src="/assets/js/mathjax-script-type.js">
 </script>
 
 <!-- Copied from https://docs.mathjax.org/en/latest/web/components/combined.html -->


### PR DESCRIPTION
I believe the path on line 3 for this script should be from the directory root rather than `/just-the-docs-tests`:

From this:
`src="/just-the-docs-tests/assets/js/mathjax-script-type.js">`

To this: 
`src="/assets/js/mathjax-script-type.js">`.

The former version will still work when not required but causes this error message: ERROR `/just-the-docs-tests/assets/js/mathjax-script-type.js' not found.